### PR TITLE
Update spf-parser.sh

### DIFF
--- a/spf-parser.sh
+++ b/spf-parser.sh
@@ -25,9 +25,9 @@ get_domains(){
 			[[ ${DIG[i]} =~ "ptr:" ]] && PTR+=( ${DIG[i]##ptr:} )
 			[[ ${DIG[i]} =~ "redirect=" ]] && redirect+=( ${DIG[i]##redirect=} ) && REDIRECT+=( ${DIG[i]##redirect=} )
 			[[ ${DIG[i]} =~ "a" ]] && IPS+=( $(dig +short -tA $PRIMARY_DOMAIN) )
-			[[ ${DIG[i]} =~ "mx" ]] && domain+=( $(dig +short -tMX $PRIMARY_DOMAIN) )
+			[[ ${DIG[i]} =~ "mx" ]] && domain+=( $(dig +short -tMX $PRIMARY_DOMAIN | awk '{print $2}') )
 			[[ ${DIG[i]} =~ "a:" ]] && IPS+=( $(dig +short -tA $i) )
-			[[ ${DIG[i]} =~ "mx:" ]] && domain+=( $(dig +short -tMX $i) )
+			[[ ${DIG[i]} =~ "mx:" ]] && domain+=( $(dig +short -tMX $i | awk '{print $2}') )
 			[[ ${DIG[i]} =~ "ip4:" ]] && IPS+=( ${DIG[i]##ip4:} )
 		}
 	else


### PR DESCRIPTION
if 'mx' is listed in SPF the mx priorities number show up in the list of domains and we only care about the mx record names when printing out the list of domains involved. Guessing it also does something similar with mx: values but couldn't find one to check that.  So suggesting to just drop the priority number with a simple awk.

example: ./spf-parser.sh att.com
DOMAINS: 10 mx0a-00191d01.pphosted.com. 10 mx0b-00191d01.pphosted.com. spf-00191d01.pphosted.com

note the two "10" values.